### PR TITLE
[auth] finish realmlist functionalites

### DIFF
--- a/wow/core/src/main/resources/application.conf
+++ b/wow/core/src/main/resources/application.conf
@@ -29,6 +29,11 @@ wow {
         username = "ensiwow"
         password = ""
       }
+      capacity = 3
+      tpe = "PvP"
+      flags = []
+      lock = false
+      time-zone = "Development"
     }
   }
 }

--- a/wow/core/src/main/scala/wow/Application.scala
+++ b/wow/core/src/main/scala/wow/Application.scala
@@ -1,51 +1,58 @@
 package wow
 
-import akka.actor.ActorSystem
+import akka.actor.{Actor, ActorLogging, ActorSystem, Props}
 import akka.http.scaladsl.settings.ServerSettings
 import pureconfig._
 import scalikejdbc.ConnectionPool
 import wow.api.WebServer
-import wow.auth.AuthServer
+import wow.auth.{AccountsState, AuthServer}
 import wow.common.config.deriveIntMap
 import wow.common.database.Database
 import wow.realm.RealmServer
 import wow.utils.Reflection
 
-/**
-  * Created by sknz on 1/31/17.
-  */
+class Application extends Actor with ActorLogging {
+  Reflection.eagerLoadClasses()
+
+  Database.configure()
+
+  context.actorOf(AccountsState.props, AccountsState.PreferredName)
+  context.actorOf(AuthServer.props, AuthServer.PreferredName)
+  for (id <- Application.configuration.realms.keys) {
+    context.actorOf(RealmServer.props(id), RealmServer.PreferredName(id))
+  }
+
+  override def postStop(): Unit = {
+    // In case any latent connections remain, close them
+    // Should not be useful, as actors would close their own connections
+    ConnectionPool.closeAll()
+
+    super.postStop()
+  }
+
+  override def receive: Receive = PartialFunction.empty
+}
+
 object Application {
   private var startTime: Long = _
 
   val configuration: ApplicationConfiguration = loadConfigOrThrow[ApplicationConfiguration]("wow")
 
   def main(args: Array[String]): Unit = {
-    Reflection.eagerLoadClasses()
-
-    Database.configure()
 
     val system = ActorSystem("wow")
+    system.actorOf(Props(new Application), "app")
 
     startTime = System.currentTimeMillis()
-
-    system.actorOf(AuthServer.props, AuthServer.PreferredName)
-    for (id <- configuration.realms.keys) {
-      system.actorOf(RealmServer.props(id), RealmServer.PreferredName(id))
-    }
-
     WebServer.startServer(configuration.webServer.host, configuration.webServer.port, ServerSettings(system), system)
 
     system.terminate()
-
-    // In case any latent connections remain, close them
-    // Should not be useful, as actors would close their own connections
-    ConnectionPool.closeAll()
   }
 
   def uptimeMillis(): Long = {
     System.currentTimeMillis() - startTime
   }
 
-  val ActorPath = "akka://wow/user"
+  val ActorPath = "akka://wow/user/app/"
 }
 

--- a/wow/core/src/main/scala/wow/ApplicationConfiguration.scala
+++ b/wow/core/src/main/scala/wow/ApplicationConfiguration.scala
@@ -5,7 +5,7 @@ import wow.auth.AuthServerConfiguration
 import wow.realm.RealmServerConfiguration
 
 /**
-  * Created by sknz on 5/6/17.
+  * Application's configuration
   */
 case class ApplicationConfiguration(
   webServer: WebServerConfiguration,

--- a/wow/core/src/main/scala/wow/auth/AccountsState.scala
+++ b/wow/core/src/main/scala/wow/auth/AccountsState.scala
@@ -1,0 +1,60 @@
+package wow.auth
+
+import akka.actor.{Actor, ActorLogging, ActorRef, Props, Terminated}
+import wow.Application
+import wow.auth.AccountsState.{AccountIdentifier, IsOnline, NotifyAccountOnline}
+
+import scala.collection.mutable
+
+/**
+  * Tracks online state for every account
+  */
+class AccountsState extends Actor with ActorLogging {
+  /**
+    * Map of actor ref representing account (NetworkWorker) by account identifier (login -> NetworkWorker ref)
+    */
+  private val accountRefById = new mutable.HashMap[AccountIdentifier, ActorRef]()
+
+  /**
+    * Map of account identifier by actor ref  (NetworkWorker ref -> login)
+    */
+  private val accountByActor = new mutable.HashMap[ActorRef, AccountIdentifier]()
+
+  override def receive: Receive = {
+    case NotifyAccountOnline(id, networkWorker) =>
+      accountRefById(id) = networkWorker
+      accountByActor(networkWorker) = id
+      context.watch(networkWorker)
+
+    case Terminated(subject) =>
+      accountByActor.remove(subject).foreach(id => accountRefById.remove(id))
+
+    case IsOnline(id) =>
+      sender ! accountRefById.contains(id)
+  }
+}
+
+object AccountsState {
+  type AccountIdentifier = String
+
+  def props: Props = Props(new AccountsState)
+
+  val PreferredName = "AccountsState"
+  val ActorPath = s"${Application.ActorPath}/$PreferredName"
+
+  /**
+    * Marks an account as online and ties its online state to the NetworkWorker
+    *
+    * @param id            account id
+    * @param networkWorker associated network worker
+    */
+  case class NotifyAccountOnline(id: AccountIdentifier, networkWorker: ActorRef)
+
+  /**
+    * Asks if an account is online.
+    *
+    * @param id account identifier
+    */
+  case class IsOnline(id: AccountIdentifier)
+}
+

--- a/wow/core/src/main/scala/wow/auth/RealmInfo.scala
+++ b/wow/core/src/main/scala/wow/auth/RealmInfo.scala
@@ -1,0 +1,48 @@
+package wow.auth
+
+import wow.auth.protocol.RealmFlags
+import wow.auth.protocol.packets.ServerRealmlistEntry
+import wow.realm.RealmServerConfiguration
+
+/**
+  * Information about realm (from the point of view of the authserver)
+  */
+case class RealmInfo(
+  id: Int,
+  realmConfig: RealmServerConfiguration,
+  var flags: RealmFlags.ValueSet = RealmFlags.ValueSet(),
+  private var _population : Float = 0.0f
+) {
+  require(id > 0)
+
+  def population: Float = _population
+
+  def population_=(newPopulation: Float): Unit = {
+    require(newPopulation >= 0)
+
+    _population = Math.min(1.0f, newPopulation)
+
+    if (population >= 0.90f) {
+      flags = flags + RealmFlags.Full
+    } else {
+      flags = flags - RealmFlags.Full
+    }
+  }
+
+  /**
+    * Get the ServerRealmlist packet entry for this realm
+    * @param charactersCount number of characters
+    * @return ServerRealmlistEntry for this realm
+    */
+  def toEntry(charactersCount: Int): ServerRealmlistEntry = ServerRealmlistEntry(realmConfig.tpe,
+    lock = realmConfig.lock,
+    realmConfig.flags ++ flags,
+    realmConfig.name,
+    s"${realmConfig.host}:${realmConfig.port}",
+    // from experiment in client: 0.9 shows as low, 1.0 as medium, 1.1 as high, thus:
+    0.8f + Math.ceil(_population * 3).toFloat * 0.1f,
+    charactersCount,
+    realmConfig.timeZone,
+    id)
+}
+

--- a/wow/core/src/main/scala/wow/auth/handlers/LogonProofHandler.scala
+++ b/wow/core/src/main/scala/wow/auth/handlers/LogonProofHandler.scala
@@ -1,11 +1,18 @@
 package wow.auth.handlers
 
+import akka.pattern.ask
+import akka.util.Timeout
+import wow.auth.AccountsState
+import wow.auth.AccountsState.IsOnline
 import wow.auth.data.Account
 import wow.auth.protocol.AuthResults
 import wow.auth.protocol.packets.{ClientLogonProof, ServerLogonProof, ServerLogonProofFailure, ServerLogonProofSuccess}
 import wow.auth.session.AuthSession.EventIncoming
 import wow.auth.session._
 import wow.auth.utils.PacketSerializer
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
 
 /**
   * Handles logon proofs
@@ -21,13 +28,25 @@ trait LogonProofHandler {
 
       srp6.verify(login, packet.clientKey, packet.clientProof, srp6Identity, srp6Challenge) match {
         case Some(srp6Validation) =>
-          Account.saveSessionKey(login, srp6Validation.sharedKey)
+          val accountState = context.actorSelection(AccountsState.ActorPath)
 
-          sendPacket(ServerLogonProof(AuthResults.Success,
-            Some(ServerLogonProofSuccess(srp6Validation.serverProof)),
-            None))
+          implicit val timeout = Timeout(5 seconds)
+          val askIsOnline = (accountState ? IsOnline(login)).mapTo[Boolean]
+          val isOnline = Await.result(askIsOnline, timeout.duration)
 
-          goto(StateRealmlist) using NoData
+          if (isOnline) {
+            sendPacket(ServerLogonProof(AuthResults.FailAlreadyOnline, None, Some(ServerLogonProofFailure())))
+
+            goto(StateFailed) using NoData
+          } else {
+            Account.saveSessionKey(login, srp6Validation.sharedKey)
+
+            sendPacket(ServerLogonProof(AuthResults.Success,
+              Some(ServerLogonProofSuccess(srp6Validation.serverProof)),
+              None))
+
+            goto(StateRealmlist) using NoData
+          }
         case None =>
           sendPacket(ServerLogonProof(AuthResults.FailUnknownAccount, None, Some(ServerLogonProofFailure())))
           goto(StateFailed) using NoData

--- a/wow/core/src/main/scala/wow/auth/handlers/ReconnectProofHandler.scala
+++ b/wow/core/src/main/scala/wow/auth/handlers/ReconnectProofHandler.scala
@@ -24,13 +24,13 @@ trait ReconnectProofHandler {
       val account = Account.findByLogin(login)
       val (nextState, authResult) = account match {
         case Some(Account(_, _, _, Some(sessionKey))) if reverify(sessionKey) =>
-          (StateRealmlist, AuthResults.Success)
+          (goto(StateRealmlist) using RealmsListData(), AuthResults.Success)
         case _ =>
-          (StateFailed, AuthResults.FailUnknownAccount)
+          (goto(StateFailed) using NoData, AuthResults.FailUnknownAccount)
       }
 
       sendPacket(ServerReconnectProof(authResult))
-      goto(nextState) using NoData
+      nextState
   }
 }
 

--- a/wow/core/src/main/scala/wow/auth/protocol/RealmFlags.scala
+++ b/wow/core/src/main/scala/wow/auth/protocol/RealmFlags.scala
@@ -1,0 +1,19 @@
+package wow.auth.protocol
+
+import wow.common.config.ConfigConvertible
+
+/**
+  * Realm flags
+  */
+object RealmFlags extends Enumeration with ConfigConvertible {
+  val None = Value(0x00)
+  val VersionMismatch = Value(0x01)
+  val Offline = Value(0x02)
+  val SpecifyBuild = Value(0x04)
+  val Medium = Value(0x08)
+  val Medium2 = Value(0x10)
+  val Recommended = Value(0x20)
+  val New = Value(0x40)
+  val Full = Value(0x80)
+}
+

--- a/wow/core/src/main/scala/wow/auth/protocol/RealmTimeZones.scala
+++ b/wow/core/src/main/scala/wow/auth/protocol/RealmTimeZones.scala
@@ -1,0 +1,41 @@
+package wow.auth.protocol
+
+import pureconfig._
+import wow.common.config._
+
+/**
+  * Time zones enumeration for realms
+  */
+object RealmTimeZones extends Enumeration with ConfigConvertible {
+  implicit val ec: ConfigConvert[RealmTimeZones.Value] = deriveEnumValue(this)
+
+  val Development = Value(1)
+  val UnitedStates = Value(2)
+  val Oceanic = Value(3)
+  val LatinAmerica = Value(4)
+  val Tournament1 = Value(5)
+  val Korea = Value(6)
+  val Tournament2 = Value(7)
+  val English = Value(8)
+  val German = Value(9)
+  val French = Value(10)
+  val Spanish = Value(11)
+  val Russian = Value(12)
+  val Tournament3 = Value(13)
+  val Taiwan = Value(14)
+  val Tournament4 = Value(15)
+  val China = Value(16)
+  val CN1 = Value(17)
+  val CN2 = Value(18)
+  val CN3 = Value(19)
+  val CN4 = Value(20)
+  val CN5 = Value(21)
+  val CN6 = Value(22)
+  val CN7 = Value(23)
+  val CN8 = Value(24)
+  val Tournament5 = Value(25)
+  val TestServer = Value(26)
+  val Tournament6 = Value(27)
+  val QAServer = Value(28)
+  val CN9 = Value(29)
+}

--- a/wow/core/src/main/scala/wow/auth/protocol/RealmTypes.scala
+++ b/wow/core/src/main/scala/wow/auth/protocol/RealmTypes.scala
@@ -1,0 +1,17 @@
+package wow.auth.protocol
+
+import pureconfig.ConfigConvert
+import wow.common.config._
+
+/**
+  * Realm types
+  */
+object RealmTypes extends Enumeration with ConfigConvertible {
+  implicit val ec: ConfigConvert[RealmTypes.Value] = deriveEnumValue(this)
+
+  val Normal       = Value(0)
+  val Pvp          = Value(1)
+  val Normal2      = Value(4)
+  val Rp           = Value(6)
+  val RpPvp        = Value(8)
+}

--- a/wow/core/src/main/scala/wow/auth/protocol/packets/ServerRealmlist.scala
+++ b/wow/core/src/main/scala/wow/auth/protocol/packets/ServerRealmlist.scala
@@ -1,9 +1,9 @@
 package wow.auth.protocol.packets
 
-import wow.auth.protocol.{OpCodes, ServerPacket}
-import wow.common.codecs._
 import scodec._
 import scodec.codecs._
+import wow.auth.protocol._
+import wow.common.codecs._
 
 import scala.collection.immutable
 
@@ -14,32 +14,34 @@ import scala.collection.immutable
   * @param lock            1 if it is locked otherwise 0
   * @param flags           the flags associated to the realm
   * @param name            the realm's name
-  * @param ip              the ip address to which the response will be sent
+  * @param address         the ip address of the realm
   * @param populationLevel the population level represented by a float
   * @param characterCount  number of characters on the realm
-  * @param timezone        the time zone
+  * @param timeZone        the time zone
   * @param id              the identifier
   */
-case class ServerRealmlistEntry(realmType: Int,
-                                lock: Int,
-                                flags: Int,
-                                name: String,
-                                ip: String,
-                                populationLevel: Float,
-                                characterCount: Int,
-                                timezone: Int,
-                                id: Int)
+case class ServerRealmlistEntry(
+  realmType: RealmTypes.Value,
+  lock: Boolean,
+  flags: RealmFlags.ValueSet,
+  name: String,
+  address: String,
+  populationLevel: Float,
+  characterCount: Int,
+  timeZone: RealmTimeZones.Value,
+  id: Int) {
+}
 
 object ServerRealmlistEntry {
   implicit val codec: Codec[ServerRealmlistEntry] = {
-    ("realmType" | uint8L) ::
-      ("lock" | uint8L) ::
-      ("flag" | uint8L) ::
+    ("realmType" | enumerated(uint8L, RealmTypes)) ::
+      ("lock" | bool(8)) ::
+      ("flag" | fixedBitmask(uint8L, RealmFlags)) ::
       ("name" | cstring) ::
-      ("ip" | cstring) ::
+      ("address" | cstring) ::
       ("populationLevel" | floatL) ::
       ("characterCount" | uint8L) ::
-      ("timezone" | uint8L) ::
+      ("timezone" | enumerated(uint8L, RealmTimeZones)) ::
       ("id" | uint8L)
   }.as[ServerRealmlistEntry]
 }

--- a/wow/core/src/main/scala/wow/auth/session/AuthSession.scala
+++ b/wow/core/src/main/scala/wow/auth/session/AuthSession.scala
@@ -78,6 +78,8 @@ class AuthSession(override val connection: ActorRef) extends TCPSession
     case _ -> StateRealmlist =>
       val login = nextStateData.asInstanceOf[RealmsListData].login
 
+      import context.dispatcher
+
       Future {
         import scala.concurrent.blocking
 

--- a/wow/core/src/main/scala/wow/auth/session/AuthSessionData.scala
+++ b/wow/core/src/main/scala/wow/auth/session/AuthSessionData.scala
@@ -1,6 +1,10 @@
 package wow.auth.session
 
+import scodec.bits.BitVector
+import wow.auth.AuthServer
 import wow.auth.crypto.{Srp6Challenge, Srp6Identity}
+import wow.auth.protocol.packets.ServerRealmlist
+import wow.auth.utils.PacketSerializer
 
 /**
   * Data
@@ -19,9 +23,10 @@ case object NoData extends AuthSessionData
   * @param srp6Identity  identity
   * @param srp6Challenge emitted challenge
   */
-case class ChallengeData(login: String,
-                         srp6Identity: Srp6Identity,
-                         srp6Challenge: Srp6Challenge) extends AuthSessionData
+case class ChallengeData(
+  login: String,
+  srp6Identity: Srp6Identity,
+  srp6Challenge: Srp6Challenge) extends AuthSessionData
 
 /**
   * Validated proof related data
@@ -33,7 +38,27 @@ case class ProofData(challengeData: ChallengeData, sharedKey: BigInt) extends Au
 
 /**
   * Data related to the reconnect challenge
-  * @param login login
+  *
+  * @param login  login
   * @param random random value used for encryption
   */
 case class ReconnectChallengeData(login: String, random: BigInt) extends AuthSessionData
+
+/**
+  * Data related to the realms list state
+  *
+  * @param bits bits of packet
+  */
+case class RealmsListData(login: String, bits: BitVector) extends AuthSessionData
+
+object RealmsListData {
+  def apply(login: String ,charactersPerRealm: Map[Int, Int] = Map.empty): RealmsListData = {
+    val realmEntries = for (realm <- AuthServer.realms.values) yield {
+      realm.toEntry(charactersPerRealm.getOrElse(realm.id, 0))
+    }
+
+    val bits = PacketSerializer.serialize(ServerRealmlist(realmEntries.toStream))
+
+    RealmsListData(login, bits)
+  }
+}

--- a/wow/core/src/main/scala/wow/common/codecs/codecs.scala
+++ b/wow/core/src/main/scala/wow/common/codecs/codecs.scala
@@ -4,7 +4,6 @@ import scodec.Attempt.{Failure, Successful}
 import scodec.bits.{BitVector, ByteVector}
 import scodec.codecs._
 import scodec.{Attempt, Codec, DecodeResult, Decoder, Encoder, Err, SizeBound}
-import wow.realm.protocol.objectupdates.UpdateFlags
 
 import scala.collection.{immutable, mutable}
 import scala.language.postfixOps
@@ -118,6 +117,7 @@ package object codecs {
     } else {
       SmallSize
     })
+
     bool(1).consume[Int](codecProvider)(_ >= Boundary)
   }
 
@@ -273,7 +273,7 @@ package object codecs {
     * @tparam I integer type for bitmask
     * @return bitmask codec
     */
-  def fixedBitmask[A <: Enumeration, I](e: A, codec: Codec[I])
+  def fixedBitmask[A <: Enumeration, I](codec: Codec[I], e: A)
     (implicit numeric: Integral[I]): Codec[e.ValueSet] = new Codec[e.ValueSet] {
 
     import numeric._
@@ -281,7 +281,7 @@ package object codecs {
     private type ValueSet = e.ValueSet
     private val ValueSet = e.ValueSet
 
-    require(UpdateFlags.values.max.id <= math.pow(2L, codec.sizeBound.exact.get - 1L).toInt)
+    require(e.values.max.id <= math.pow(2L, codec.sizeBound.exact.get - 1L).toInt)
 
     override def decode(bits: BitVector): Attempt[DecodeResult[ValueSet]] = {
       codec.decode(bits) match {

--- a/wow/core/src/main/scala/wow/common/config/ConfigConvertible.scala
+++ b/wow/core/src/main/scala/wow/common/config/ConfigConvertible.scala
@@ -1,0 +1,19 @@
+package wow.common.config
+
+/**
+  * Makes an enumeration config convertible
+  */
+trait ConfigConvertible {
+  this: Enumeration =>
+
+  /**
+    * Config converter for Value type
+    */
+  implicit val valueConfigConverter = wow.common.config.deriveEnumValue(this)
+
+  /**
+    * Config converter for ValueSet type
+    */
+  implicit val valueSetConfigConverter = wow.common.config.deriveEnumValueSet(this)
+}
+

--- a/wow/core/src/main/scala/wow/common/database/DatabaseHelpers.scala
+++ b/wow/core/src/main/scala/wow/common/database/DatabaseHelpers.scala
@@ -1,0 +1,23 @@
+package wow.common.database
+
+import org.flywaydb.core.Flyway
+import scalikejdbc.ConnectionPool
+
+/**
+  * Database setup helpers (e.g. migration, connection)
+  */
+object DatabaseHelpers {
+  def connect(db: Databases.Value, dbConfig: DatabaseConfiguration): Unit = {
+    ConnectionPool.add(db, dbConfig.connection, dbConfig.username, dbConfig.password)
+  }
+
+  def migrate(migrationName: String, dbConfig: DatabaseConfiguration): Unit = {
+    val migration = new Flyway()
+
+    migration.setDataSource(dbConfig.connection, dbConfig.username, dbConfig.password)
+    migration.setLocations(s"classpath:db/$migrationName")
+    migration.baseline()
+    migration.migrate()
+    migration.validate()
+  }
+}

--- a/wow/core/src/main/scala/wow/common/network/TCPServer.scala
+++ b/wow/core/src/main/scala/wow/common/network/TCPServer.scala
@@ -2,7 +2,7 @@ package wow.common.network
 
 import java.net.InetSocketAddress
 
-import akka.actor.{Actor, ActorLogging, Props}
+import akka.actor.{Actor, ActorLogging, Props, SupervisorStrategy}
 import akka.io.Tcp._
 import akka.io.{IO, Tcp}
 
@@ -18,7 +18,9 @@ class TCPServer[A <: TCPSessionFactory](val factory: A, val address: String, val
   log.debug("Binding server with socket")
   IO(Tcp)(context.system) ! Bind(self, new InetSocketAddress(address, port))
 
-  override def postStop(): Unit = log.debug("Stopped")
+  override def supervisorStrategy: SupervisorStrategy = SupervisorStrategy.stoppingStrategy
+
+  override def postStop(): Unit = log.debug(s"Stopped TCP server for $address:$port")
 
   def receive: PartialFunction[Any, Unit] = {
     case Bound(localAddress) =>

--- a/wow/core/src/main/scala/wow/realm/entities/CharacterInfo.scala
+++ b/wow/core/src/main/scala/wow/realm/entities/CharacterInfo.scala
@@ -42,7 +42,9 @@ object CharacterRef {
 }
 
 object CharacterInfo {
-  def countByRealm(implicit realm: RealmContextData): Int = charactersByGuid.size
+  def countByRealm(implicit realm : RealmContextData): Int = {
+    charactersByGuid.size + realm.id - realm.id
+  }
 
   def countByAccountPerRealm(login: String): Map[Int, Int] = Map(1 -> charactersByGuid.size)
 

--- a/wow/core/src/main/scala/wow/realm/entities/CharacterInfo.scala
+++ b/wow/core/src/main/scala/wow/realm/entities/CharacterInfo.scala
@@ -3,6 +3,7 @@ package wow.realm.entities
 import wow.realm.protocol.payloads.CharacterDescription
 import scodec.bits._
 import scodec.codecs._
+import wow.realm.RealmContextData
 
 import scala.collection.parallel.mutable
 import scala.collection.{GenIterable, parallel}
@@ -41,6 +42,9 @@ object CharacterRef {
 }
 
 object CharacterInfo {
+  def countByRealm(implicit realm: RealmContextData): Int = charactersByGuid.size
+
+  def countByAccountPerRealm(login: String): Map[Int, Int] = Map(1 -> charactersByGuid.size)
 
   def apply(guid: Guid,
             position: Position,

--- a/wow/core/src/main/scala/wow/realm/protocol/payloads/ServerUpdateObject.scala
+++ b/wow/core/src/main/scala/wow/realm/protocol/payloads/ServerUpdateObject.scala
@@ -82,7 +82,7 @@ case class MovementInfo(
 
 object MovementInfo {
   implicit val codec: Codec[MovementInfo] = {
-    ("updateFlags" | fixedBitmask(UpdateFlags, uint16L)) ::
+    ("updateFlags" | fixedBitmask(uint16L, UpdateFlags)) ::
       ("movementFlags" | uint32L) ::
       ("extraMovementFlags" | uint16L) ::
       ("msTime" | uint32L) ::

--- a/wow/core/src/main/scala/wow/realm/session/CanSendPackets.scala
+++ b/wow/core/src/main/scala/wow/realm/session/CanSendPackets.scala
@@ -10,9 +10,17 @@ import wow.realm.protocol._
   */
 private[session] trait CanSendPackets extends Actor with ActorLogging {
   /**
+    * Sends the opcode without payload to the client
+    *
+    * @param opCode op code to be sent
+    */
+  def sendOpCode(opCode: OpCodes.Value) = sendRaw(BitVector.empty, opCode)
+
+  /**
     * Serializes and sends the payload
-    * @param payload payload
-    * @param codec codec for payload
+    *
+    * @param payload        payload
+    * @param codec          codec for payload
     * @param opCodeProvider opcode provider for payload
     * @tparam A payload type
     */
@@ -22,21 +30,24 @@ private[session] trait CanSendPackets extends Actor with ActorLogging {
   /**
     * Sends the payload while prepending it with the header corresponding to opCode.
     * Cipher will be applied to header if applicable.
+    *
     * @param payloadBits payload bits
-    * @param opCode opcode
+    * @param opCode      opcode
     */
   def sendRaw(payloadBits: BitVector, opCode: OpCodes.Value): Unit
 
   /**
     * Sends the payload while prepending it with the header bits
     * Cipher will be applied to header if applicable.
+    *
     * @param payloadBits payload bits
-    * @param headerBits header bits
+    * @param headerBits  header bits
     */
   def sendRaw(headerBits: BitVector, payloadBits: BitVector): Unit
 
   /**
     * Send the bits as passed.
+    *
     * @param bits bits to be sent
     */
   def sendRaw(bits: BitVector): Unit

--- a/wow/core/src/main/scala/wow/realm/session/Session.scala
+++ b/wow/core/src/main/scala/wow/realm/session/Session.scala
@@ -1,6 +1,8 @@
 package wow.realm.session
 
-import akka.actor.{Actor, ActorLogging, ActorRef, Props}
+import akka.actor.{Actor, ActorLogging, ActorRef, Props, Terminated}
+import wow.auth.AccountsState
+import wow.auth.AccountsState.NotifyAccountOnline
 import wow.realm.entities.Guid
 import wow.realm.protocol._
 import wow.realm.session.Session.CreatePlayer
@@ -17,14 +19,21 @@ class Session(val login: String, override val networkWorker: ActorRef)(override 
           with ForwardToNetworkWorker {
   var player: Option[ActorRef] = _
 
+  context.actorSelection(AccountsState.ActorPath) ! NotifyAccountOnline(login, networkWorker)
+
   override def receive: Receive = {
     case CreatePlayer(guid: Guid) =>
       val ref = context.actorOf(SessionPlayer.props(guid, networkWorker), SessionPlayer.PreferredName(guid))
       player = Some(ref)
       sender() ! ref
+      context.watch(ref)
 
     case NetworkWorker.HandlePacket(header, payloadBits) =>
       PacketHandler(header, payloadBits)(this)
+
+    case Terminated(subject) if subject == player.getOrElse(ActorRef.noSender) =>
+      // Bring player back to character screen is its player actor crashes
+      sendOpCode(OpCodes.SLogoutComplete)
   }
 }
 

--- a/wow/core/src/main/scala/wow/utils/AutoRestartSupervisor.scala
+++ b/wow/core/src/main/scala/wow/utils/AutoRestartSupervisor.scala
@@ -1,0 +1,17 @@
+package wow.utils
+
+import akka.actor.SupervisorStrategy.Restart
+import akka.actor.{Actor, ActorLogging, OneForOneStrategy, Props, SupervisorStrategy}
+
+/**
+  * Automatically restarts its child actor
+  */
+class AutoRestartSupervisor(childProps: Props, childName: String) extends Actor with ActorLogging {
+  override def supervisorStrategy: SupervisorStrategy = OneForOneStrategy() {
+    case _ => Restart
+  }
+
+  context.actorOf(childProps, childName)
+
+  override def receive: Receive = PartialFunction.empty
+}

--- a/wow/core/src/test/scala/wow/auth/protocol/AuthPacketTests.scala
+++ b/wow/core/src/test/scala/wow/auth/protocol/AuthPacketTests.scala
@@ -109,14 +109,14 @@ class ServerRealmlistTest extends AuthPacketTest[ServerRealmlist](
   hex"1029000000000001000100025472696E697479003132372E302E302E313A3830383500000000000101011000",
   ServerRealmlist(realms = Vector(
         ServerRealmlistEntry(
-          realmType = 1,
-          lock = 0,
-          flags = 0x2,
+          realmType = RealmTypes.Pvp,
+          lock = false,
+          flags = RealmFlags.ValueSet(RealmFlags.Offline),
           name = "Trinity",
-          ip = "127.0.0.1:8085",
+          address = "127.0.0.1:8085",
           populationLevel = 0.0f,
           characterCount = 1,
-          timezone = 1,
+          timeZone = RealmTimeZones.Development,
           id = 1
         )
       ))


### PR DESCRIPTION
* make capacity, type, flags, lock state, timezone configurable
* add enumeration for realm type/flags/timezones
* update ServerRealmlistEntry accordingly
* add enumeration support for pureconfig (ConfigConvertible trait)
* add Application actor as base actor
* add AccountsState actor to track online accounts
* add check to see if account is online, if so fail auth
    * in AuthServer and RealmServer both
* implement showing realm population in auth server
    * still needs db-backed character count to give real values
* add realm actor status watch to authserver (online/offline)
* factorize database migration/opening connections in DatabaseHelpers
* implement character count in realmlist
* fix typo-induced bug in fixedBitmask requirements
* add supervisor for AuthServer actor to restart it in case of crash
* stop NetworkWorker when Session dies, and stop Session when
NetworkWorker dies
* if SessionPlayer actor stops, bring client back to char selection
screen